### PR TITLE
QoL: Add a binding to fast-forward to the last input and mute audio by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ On the right, you'll see the pianoroll, which shows the inputs in the frames aro
 * __Shift__ + __controller button__ - toggle hold of the respective button. held buttons will be pressed when advancing/rewinding to a frame
 * __D__ - preform a full-rewind, return to frame 0
 * __P__ - start realtime playback. The TAS will play back in real time, and inputs can't be modified. any keypress during realtime playback will stop it.
+* __Shift + P__ - fast forward until the last input frame
 * __Shift + R__ - reset, clear the inputs, and rewind to frame 0
 * __M__ - save the current inputs to a file <cartname>.lua, in the games data folder (By default, on windows this is %appdata%/love/Celia, and on linux ~/.local/share/love/Celia). The filepath will be outputted to the terminal.
 * __Shift + W__ - Load the input file from the data folder

--- a/cctas.lua
+++ b/cctas.lua
@@ -472,6 +472,13 @@ function cctas:full_rewind()
 	self:reset_editor_state()
 end
 
+function cctas:goto_frame(i)
+	self.super.goto_frame(self, i)
+
+	self:state_changed()
+	self:reset_editor_state()
+end
+
 function cctas:full_reset()
 	self.super.full_reset(self)
 

--- a/main.lua
+++ b/main.lua
@@ -337,6 +337,8 @@ function love.load(argv)
 		}
 	end
 
+	love.audio.setVolume(0)
+
 	love.graphics.clear()
 	love.graphics.setDefaultFilter("nearest", "nearest")
 	pico8.screen =
@@ -520,6 +522,9 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 screen_coords) 
 			elseif argv[argpos] == "--fixp" then
 				paramcount = 0
 				fix32.init()
+			elseif argv[argpos] == "--audio" then
+				paramcount = 0
+				love.audio.setVolume(1)
 			elseif tas_tools[argv[argpos]] and tas_tool_name == nil then
 				paramcount = 0
 				tas_tool_name = argv[argpos]

--- a/tas.lua
+++ b/tas.lua
@@ -207,6 +207,23 @@ function tas:full_rewind()
 	self:rewind()
 end
 
+function tas:goto_frame(i)
+	if self:frame_count() < i then
+		self.seek = {
+			finish_condition = function()
+				return self:frame_count() >= i
+			end,
+			on_finish = function() end,
+			fast_forward = true,
+		}
+	elseif 0 <= i and i < self:frame_count() then
+		while i < self:frame_count() - 1 do
+			self:popstate()
+		end
+		self:rewind()
+	end
+end
+
 function tas:full_reset()
 	self:full_rewind()
 	self.hold=0
@@ -476,7 +493,11 @@ function tas:keypressed(key, isrepeat)
 		end
 		self.seek=nil
 	elseif key=='p' then
-		self.realtime_playback = not self.realtime_playback
+		if love.keyboard.isDown('lshift', 'rshift') then
+			self:goto_frame(#self.keystates - 1)
+		else
+			self.realtime_playback = not self.realtime_playback
+		end
 	--TODO: block keypresses even when overloading this func
 	elseif self.last_selected_frame ~= -1 then
 		self:selection_keypress(key, isrepeat)


### PR DESCRIPTION
- Fast-forwarding to the last input is very useful when working on long files
- Muting audio by default seems a sensible choice, given that audio isn't useful when TASing