### PR TITLE
call love.resize on every frame

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -591,6 +591,7 @@ function love.update(_)
 end
 
 function love.draw()
+	love.resize(love.graphics.getWidth(), love.graphics.getHeight())
 
 	love.graphics.setFont(pico8.font)
 	love.graphics.setCanvas(pico8.screen)


### PR DESCRIPTION
this prevents weird behavior and resizing issues on some tiling window managers. the performance impact should be non-existent