### PR TITLE
pass save_state to cc2tas:pushstate so it actually saves the state

### DIFF
--- a/cc2tas.lua
+++ b/cc2tas.lua
@@ -224,11 +224,11 @@ function cc2tas:unset_player_env()
 	})
 end
 
-function cc2tas:pushstate()
+function cc2tas:pushstate(save_state)
 	if pico8.cart.level_intro == 0 then
 		self.level_time = self.level_time + 1
 	end
-	self.super.pushstate(self)
+	self.super.pushstate(self, save_state)
 end
 
 function cc2tas:popstate()


### PR DESCRIPTION
The cc2tas:pushstate parameters seemed to not get updated after savestate_every was added. This led to frames not getting saved because save_state was nil. If you rewind and there are no saved frames the tas tool while crash because there is no frame to go to (or something like that).